### PR TITLE
Refactor: Replay Buffer

### DIFF
--- a/Agents/Collections/ExperienceReplay.py
+++ b/Agents/Collections/ExperienceReplay.py
@@ -1,0 +1,155 @@
+import random
+
+from Agents.Collections import TransitionFrame
+from collections import deque
+
+class ReplayBuffer:
+    """
+    An Experience Replay Buffer for looking back and resampling transitions.
+    """
+    def __init__(self, learner, max_length, empty_trans, history_length: int = 1):
+        """
+        Constructor method
+        :param learner: the agent using this buffer
+        :type learner: Agent
+        :param max_length: the max length of this buffer
+        :type max_length: int
+        :param empty_trans: the empty transition to pad results with
+        :type empty_trans: TransitionFrame
+        :param history_length: the length of the history
+        :type history_length: int
+        """
+        self.empty_trans = empty_trans
+        self.history_length = history_length
+        self.learner = learner
+        self.max_length = max_length
+        self._transitions = deque(maxlen = max_length)
+    
+    def append_frame(self, transition_frame):
+        """
+        Appends a given framed to the buffer.
+        :param transition_frame: the transition frame to append to the end
+        of this buffer
+        :type transition_frame: TransitionFrame
+        """
+        if (not isinstance(transition_frame, TransitionFrame.TransitionFrame)):
+            raise ValueError("Only transition frames can be added to the replay buffer.")
+        self._transitions.append(transition_frame)
+      
+    def peak_frame(self):
+        """
+        Returns the last frame if the buffer is non-empty and an empty
+        transition frame otherwise.
+        :return: the last frame added to the buffer
+        :rtype: TransitionFrame
+        """
+        if (self._transitions):
+            return self._transitions[-1]
+        return self.empty_trans
+    
+    def get_recent_action(self):
+        """
+        Get the last n actions where n is equal to the history length of the
+        buffer.
+        :return: the recent actions
+        :rtype: list
+        """
+        # Empty deque to prepend actions to.
+        result = deque(maxlen = self.history_length)
+        
+        # Get the latest action until the history length or until the beginning
+        # of the buffer is reached.
+        for i in range((len(self) - 1), max((len(self) - 1) - self.history_length, 0), -1):
+            result.appendleft(self._transitions[i].action)
+        
+        # Prepend -1s until the length of the deque equals the history
+        # length.
+        while (len(result) < self.history_length):
+            result.appendleft(-1)
+        
+        # Return the recent actions as a list.
+        return list(result)
+    
+    def get_recent_state(self):
+        """
+        Get the last n states where n is equal to the history length of the
+        buffer.
+        :return: the recent states
+        :rtype: list
+        """
+        # Empty deque to prepend states to.
+        result = deque(maxlen = self.history_length)
+        
+        # Get the latest states until the history length or until the beginning
+        # of the buffer is reached.
+        for i in range((len(self) - 1), max((len(self) - 1) - self.history_length, 0), -1):
+            result.appendleft(self._transitions[i].state)
+        
+        # Prepend empty states until the length of the deque equals the
+        # history length.
+        empty_state = self.empty_trans.state
+        while (len(result) < self.history_length):
+            result.appendleft(empty_state)
+        
+        # Return the recent states as a list.
+        return list(result)
+    
+    def get_transitions(self, start):
+        """
+        Gets a list of transition from the given index. The length of the
+        the list will be equal to the history length of the buffer.
+        :param start: is the start index to get transtions from.
+        :type start: int
+        :return: the padded transitions
+        :rtype: list
+        """
+        # Check if the index within bounds.
+        if (start < 0 or start >= len(self)):
+            raise ValueError("Start index is out of bounds.")
+        
+        # If the history length is equal to 1, just return the transition
+        # at the given index.
+        if (self.history_length == 1):
+            return self._transitions[start]
+            
+        # Empty list to store the transitions.
+        results = []
+        # Iterate through the buffer, adding transitions to the list.
+        for i in range(start, start + self.history_length):
+            results.append(self._transitions[i])
+            if self._transitions[i].is_done or i == (len(self._transitions) - 1):
+                break
+                
+        # Pad and return the transitions.
+        return self.pad(results)
+    
+    def pad(self, transitions):
+        """
+        Adds padding to the beginning of the given list of transitions.
+        :param transitions: the list of transitions to pad
+        :type transitions: list
+        :return: the padded transitions
+        :rtype: list
+        """
+        return [self.empty_trans for _ in
+               range(self.history_length - len(transitions))] + transitions
+    
+    def sample(self, batch_size):
+        """
+        Gets a number of samples equal equal to the batch size, each length
+        equal to the history length of this buffer.
+        :return: the length of the buffer
+        :rtype: int
+        """
+        result = []
+        for i in random.sample(range(len(self)), batch_size):
+            result.append(self.get_transitions(i))
+        return result
+    
+    def __len__(self):
+        """
+        Returns the length of this replay buffer.
+        :return: the length of the buffer
+        :rtype: int
+        """
+        return len(self._transitions)

--- a/Agents/Collections/TransitionFrame.py
+++ b/Agents/Collections/TransitionFrame.py
@@ -1,0 +1,12 @@
+class TransitionFrame:
+    def __init__(self, state, action, reward, next_state, is_done):
+        self.state = state
+        self.action = action
+        self.reward = reward
+        self.next_state = next_state
+        self.is_done = is_done
+
+class ActionTransitionFrame(TransitionFrame):
+    def __init__(self, prev_action, state, action, reward, next_state, is_done):
+        super().__init__(state, action, reward, next_state, is_done)
+        self.prev_action = prev_action

--- a/Agents/adrqn.py
+++ b/Agents/adrqn.py
@@ -1,13 +1,16 @@
-from Agents import drqn
 import numpy as np
-import itertools
+
+from Agents import drqn
+from Agents.Collections import ExperienceReplay
+from Agents.Collections.TransitionFrame import ActionTransitionFrame
 
 class ADRQN(drqn.DRQN):
     displayName = 'ADRQN'
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.memory = ADRQN.ReplayBuffer(self, self.memory_size, self.historylength)
+        empty_state = self.get_empty_state()
+        self.memory = ExperienceReplay.ReplayBuffer(self, self.memory_size, ActionTransitionFrame(-1, empty_state, -1, 0, empty_state, False), history_length = self.historylength)
 
     def getRecentAction(self):
         return self.memory.get_recent_action()
@@ -20,6 +23,10 @@ class ADRQN(drqn.DRQN):
         qval = self.predict((recent_state, recent_action), False)
         action = np.argmax(qval)
         return action
+
+    def addToMemory(self, state, action, reward, new_state, done):
+        prev_action = self.memory.peak_frame().action
+        self.memory.append_frame(ActionTransitionFrame(prev_action, state, action, reward, new_state, done))
 
     def predict(self, state, isTarget):
         state, action = state
@@ -78,77 +85,21 @@ class ADRQN(drqn.DRQN):
                    np.zeros((self.batch_size,) + (self.historylength,) + (self.action_size,))]
 
         for index_rep, history in enumerate(mini_batch):
-            for histInd, (prevAction, state, action, reward, next_state, isDone) in enumerate(history):
-                X_train[0][index_rep][histInd] = state
-                next_states[0][index_rep][histInd] = next_state
-                X_train[1][index_rep][histInd] = self.create_one_hot(self.action_size, prevAction)
-                next_states[1][index_rep][histInd] = self.create_one_hot(self.action_size, action)
-            X_train[2][index_rep] = self.create_one_hot(self.action_size, action)
+            for histInd, transition in enumerate(history):
+                X_train[0][index_rep][histInd] = transition.state
+                next_states[0][index_rep][histInd] = transition.next_state
+                X_train[1][index_rep][histInd] = self.create_one_hot(self.action_size, transition.prev_action)
+                next_states[1][index_rep][histInd] = self.create_one_hot(self.action_size, transition.action)
+            X_train[2][index_rep] = self.create_one_hot(self.action_size, transition.action)
 
         Y_train = np.zeros((self.batch_size,) + (self.action_size,))
         qnext = self.target.predict(next_states + [self.allBatchMask])
         qnext = np.amax(qnext, 1)
 
         for index_rep, history in enumerate(mini_batch):
-            prevAction, state, action, reward, next_state, isDone = history[-1]
-            if isDone:
-                Y_train[index_rep][action] = reward
+            transition = history[-1]
+            if transition.is_done:
+                Y_train[index_rep][transition.action] = transition.reward
             else:
-                Y_train[index_rep][action] = reward + qnext[index_rep] * self.gamma
+                Y_train[index_rep][transition.action] = transition.reward + qnext[index_rep] * self.gamma
         return X_train, Y_train
-
-
-    class ReplayBuffer(drqn.DRQN.ReplayBuffer):
-        def __init__(self, *args):
-            super().__init__(*args)
-
-            shape = self.learner.state_size
-            if len(shape) >= 2:
-                self.emptyState = np.array([[[-10000]] * shape[0] for _ in range(shape[1])])
-            else:
-                self.emptyState = np.array([-10000] * shape[0])
-            self.emptyTrans = (self.emptyState, -1, 0, self.emptyState, False)
-
-        def getTransitions(self, startInd):
-            result = []
-            limit = (self.curIndex-1)%self.maxlength
-            for ind in range(startInd, startInd+self.historylength):
-                ind %= self.maxlength
-                transition = self.transitions[ind]
-                if transition is None:
-                    break
-                prevInd = (ind-1)%self.maxlength
-                prevTransition = self.transitions[prevInd]
-                prevAction = -1
-                if prevTransition and not prevInd == limit and not prevTransition[4]:
-                    prevAction = prevTransition[1]
-                result.append((prevAction,) + transition)
-                if transition[4] or ind == limit:
-                    break
-            return self.pad(result)
-
-        def pad(self, transitions):
-            pad = [(-1, self.emptyState, -1, 0, self.emptyState, False) for _ in
-                   range(self.historylength - len(transitions))]
-            return pad + transitions
-
-        def get_recent_action(self):
-            result = [None] * self.historylength
-            resInd = self.historylength - 1
-            start = (self.curIndex - 1) % self.maxlength
-            transition = self.transitions[start]
-            result[resInd] = transition[1]
-            resInd -= 1
-            for ind in range(start - 1, start - self.historylength, -1):
-                ind %= self.maxlength
-                transition = self.transitions[ind]
-                if not transition or transition[4]:
-                    break
-                result[resInd] = transition[1]
-                resInd -= 1
-
-            while resInd >= 0:
-                result[resInd] = -1
-                resInd -= 1
-
-            return result

--- a/Agents/agent.py
+++ b/Agents/agent.py
@@ -33,6 +33,17 @@ class Agent(ABC):
         self.action_size = action_size
         self.gamma = gamma
         self.time_steps = 0
+    
+    def get_empty_state(self):
+        """
+        Gets the empty game state.
+        :return: A representation of an empty game state.
+        :rtype: list
+        """
+        shape = self.state_size
+        if len(shape) >= 2:
+            return [[[-10000]] * shape[0] for _ in range(shape[1])]
+        return [-10000] * shape[0]
 
     @abstractmethod
     def choose_action(self, state):

--- a/Agents/deepQ.py
+++ b/Agents/deepQ.py
@@ -139,9 +139,3 @@ class DeepQ(modelFreeAgent.ModelFreeAgent):
     def memload(self, mem):
         self.model.set_weights(mem)
         self.target.set_weights(mem)
-        
-    def get_empty_state(self):
-        shape = self.state_size
-        if len(shape) >= 2:
-            return [[[-10000]] * shape[0] for _ in range(shape[1])]
-        return [-10000] * shape[0]

--- a/Agents/drqn.py
+++ b/Agents/drqn.py
@@ -1,8 +1,8 @@
-from Agents import deepQ
 import numpy as np
-import random
-from collections import deque
-import itertools
+
+from Agents import deepQ
+from Agents.Collections import ExperienceReplay
+from Agents.Collections.TransitionFrame import TransitionFrame
 
 
 class DRQN(deepQ.DeepQ):
@@ -14,13 +14,14 @@ class DRQN(deepQ.DeepQ):
         paramLen = len(DRQN.newParameters)
         self.historylength = int(args[-paramLen])
         super().__init__(*args[:-paramLen])
-        self.memory = DRQN.ReplayBuffer(self, self.memory_size, self.historylength)
+        empty_state = self.get_empty_state()
+        self.memory = ExperienceReplay.ReplayBuffer(self, self.memory_size, TransitionFrame(empty_state, -1, 0, empty_state, False), history_length = self.historylength)
 
     def getRecentState(self):
         return self.memory.get_recent_state()
 
     def resetBuffer(self):
-        self.memory = DRQN.ReplayBuffer(self, self.memory_size, self.historylength)
+        self.memory = ExperienceReplay.ReplayBuffer(self, self.memory_size, self.historylength)
 
     def buildQNetwork(self):
         from tensorflow.python.keras.optimizer_v2.adam import Adam
@@ -52,21 +53,21 @@ class DRQN(deepQ.DeepQ):
         next_states = np.zeros((self.batch_size,) + (self.historylength,) + self.state_size)
 
         for index_rep, history in enumerate(mini_batch):
-            for histInd, (state, action, reward, next_state, isDone) in enumerate(history):
-                X_train[0][index_rep][histInd] = state
-                next_states[index_rep][histInd] = np.array(next_state)
-            X_train[1][index_rep] = self.create_one_hot(self.action_size, action)
+            for histInd, transition in enumerate(history):
+                X_train[0][index_rep][histInd] = transition.state
+                next_states[index_rep][histInd] = np.array(transition.next_state)
+            X_train[1][index_rep] = self.create_one_hot(self.action_size, transition.action)
 
         Y_train = np.zeros((self.batch_size,) + (self.action_size,))
         qnext = self.target.predict([next_states, self.allBatchMask])
         qnext = np.amax(qnext, 1)
 
         for index_rep, history in enumerate(mini_batch):
-            state, action, reward, next_state, isDone = history[-1]
-            if isDone:
-                Y_train[index_rep][action] = reward
+            transition = history[-1]
+            if transition.is_done:
+                Y_train[index_rep][transition.action] = transition.reward
             else:
-                Y_train[index_rep][action] = reward + qnext[index_rep] * self.gamma
+                Y_train[index_rep][transition.action] = transition.reward + qnext[index_rep] * self.gamma
         return X_train, Y_train
 
     def choose_action(self, state):
@@ -86,80 +87,3 @@ class DRQN(deepQ.DeepQ):
         else:
             result = self.model.predict([state, self.allMask])
         return result
-
-    def sample(self):
-        return self.memory.sample(self.batch_size)
-
-    def addToMemory(self, state, action, reward, new_state, done):
-        self.memory.appendFrame(state, action, reward, new_state, done)
-
-
-    class ReplayBuffer:
-        def __init__(self, learner, maxlength, historylength):
-            self.learner = learner
-            self.maxlength = maxlength
-            self.historylength = historylength
-            self.transitions = [None]*self.maxlength
-            self.curIndex = 0
-            emptyState = self.getEmptyState()
-            self.emptyTrans = (emptyState, -1, 0, emptyState, False)
-
-        def __len__(self):
-            return self.curIndex
-
-        def getEmptyState(self):
-            shape = self.learner.state_size
-            if len(shape) >= 2:
-                return [[[-10000]] * shape[0] for _ in range(shape[1])]
-            return [-10000] * shape[0]
-
-        def appendFrame(self, state, action, reward, next_state, isdone):
-            self.transitions[self.curIndex % self.maxlength] = (state, action, reward, next_state, isdone)
-            self.curIndex += 1
-
-        def getTransitions(self, startInd):
-            result = []
-            limit = (self.curIndex-1)%self.maxlength
-            for ind in range(startInd, startInd+self.historylength):
-                ind %= self.maxlength
-                transition = self.transitions[ind]
-                if transition is None:
-                    break
-                result.append(transition)
-                if transition[4] or ind == limit:
-                    break
-            return self.pad(result)
-
-        def pad(self, transitions):
-            pad = [self.emptyTrans for _ in
-                   range(self.historylength - len(transitions))]
-            return pad + transitions
-
-        def sample(self, batch_size):
-            result = []
-            for ind in random.sample(range(min(self.maxlength, self.curIndex)), batch_size):
-                result.append(self.getTransitions(ind))
-            return result
-
-        def get_recent_state(self):
-            result = [None]*self.historylength
-            resInd = self.historylength-1
-            start = (self.curIndex-1)%self.maxlength
-            transition = self.transitions[start]
-            result[resInd] = transition[0]
-            resInd -= 1
-            for ind in range(start-1, start-self.historylength, -1):
-                ind %= self.maxlength
-                transition = self.transitions[ind]
-                if not transition or transition[4]:
-                    break
-                result[resInd] = transition[0]
-                resInd -= 1
-
-            emptyState = self.getEmptyState()
-
-            while resInd >= 0:
-                result[resInd] = emptyState
-                resInd -= 1
-
-            return result


### PR DESCRIPTION
Replay Buffer has been refactored to be decoupled from the agents and generalized so that all agent **should** be able to use it with minimal effort. Featured changes include.
- Creating a new directory called _Collections_ inside _Agents_ which stores data structures for agent modules.
- ReplayBuffer classes being removed from their respective agent classes, merged into a single class, and moved to a new python module under _/Agents/Collections/ExperienceReplay.py_.
- The _sample_ function will sample sequences regardless and the history length parameter is now optional. This makes it able to be used by DeepQ by having the default history length be one so it will sample sequences of length 1.
- To make the ReplayBuffer usable by ADRQN, I generalized the transition frame into an object so that the data is slightly more, but not completely, ambiguous to the buffer.
- The code has been condensed and the underlying data structure has been changed to a deque.

I am not sure if using a deque was the right idea because the original implementation was an original implementation of a deque. I am considering changing back to that but leave out a lot of the unnecessary code like the many **if** statements.

Also the second commit is a suggestion to move get_empty_state() to the Agent class so all agents have access to it. It is necessary to use the ReplayBuffer.